### PR TITLE
fix: use planner for new versions when production exists elsewhere

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,9 +71,10 @@ jobs:
                 [[ -n "$NEW_TAG" ]] && HAS="true"
                 [[ "$NEW_TAG" == *"-beta."* ]] && PRERELEASE="true" || PRERELEASE="false"
               else
-                echo "main: v${base} exists elsewhere but not merged here → continue beta series"
-                NEW_TAG="v${base}-beta.$((n+1))"
-                PRERELEASE="true"; HAS="true"
+                echo "main: v${base} exists elsewhere but not merged here → start new version from planner"
+                NEW_TAG="$PLANNED"
+                [[ -n "$NEW_TAG" ]] && HAS="true"
+                [[ "$NEW_TAG" == *"-beta."* ]] && PRERELEASE="true" || PRERELEASE="false"
               fi
             else
               NEW_TAG="$PLANNED"


### PR DESCRIPTION
- When v0.X.Y exists but not merged to main, use planner suggestion instead of continuing beta series
- This ensures fix commits create v0.X.Y+1-beta.0 instead of v0.X.Y-beta.N+1
- Fixes: v0.7.0-beta.2 → should be v0.7.1-beta.0

Expected behavior:
- fix: commits after v0.7.0 release → v0.7.1-beta.0
- feat: commits after v0.7.0 release → v0.8.0-beta.0