### PR TITLE
fix: correct beta version comparison logic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,13 +74,14 @@ jobs:
               
               # Compare beta base version with latest production using version sort
               if [[ -n "$LAST_PRODUCTION" ]]; then
-                # If beta base is newer than or equal to latest production, continue beta series
-                if printf '%s\n' "v${base}" "$LAST_PRODUCTION" | sort -V | tail -n1 | grep -q "v${base}"; then
-                  echo "main: beta v${base} >= production ${LAST_PRODUCTION} → continue beta series"
+                # If beta base is newer than latest production, continue beta series
+                # If beta base equals latest production, that version was released → start new cycle
+                if printf '%s\n' "v${base}" "$LAST_PRODUCTION" | sort -V | tail -n1 | grep -q "v${base}" && [[ "v${base}" != "$LAST_PRODUCTION" ]]; then
+                  echo "main: beta v${base} > production ${LAST_PRODUCTION} → continue beta series"
                   NEW_TAG="v${base}-beta.$((n+1))"
                   PRERELEASE="true"; HAS="true"
                 else
-                  echo "main: beta v${base} < production ${LAST_PRODUCTION} → start new cycle from planner"
+                  echo "main: beta v${base} <= production ${LAST_PRODUCTION} → start new cycle from planner"
                   NEW_TAG="$PLANNED"
                   [[ -n "$NEW_TAG" ]] && HAS="true"
                   [[ "$NEW_TAG" == *"-beta."* ]] && PRERELEASE="true" || PRERELEASE="false"


### PR DESCRIPTION
The critical fix: when beta base version EQUALS latest production, that means the version was already released, so we should start a NEW cycle.

Before: v0.9.1-beta.X >= v0.9.1 -> continue beta series (WRONG)
After:  v0.9.1-beta.X == v0.9.1 -> start new cycle (CORRECT)

Expected behavior after v0.9.1 release:
- fix: commit should create v0.9.2-beta.0 (not v0.9.1-beta.4)
- feat: commit should create v0.10.0-beta.0

Clean state: Deleted all v0.9.1-beta tags that should not exist after v0.9.1 release.